### PR TITLE
(updates) Change the counter for the params loop

### DIFF
--- a/web/modules/updates/updates/ajaxUpdatesListWinBlack.php
+++ b/web/modules/updates/updates/ajaxUpdatesListWinBlack.php
@@ -38,9 +38,10 @@ $count_black = $black_list['nb_element_total'];
 $kbs_black = [];
 $updateids_black = [];
 $titles_black = [];
+$count = count($black_list['title']);
 
 // ########## Set params ########## //
-for($i=0; $i < $count_black; $i++){
+for($i=0; $i < $count; $i++){
     $blackActions["unban"][] = $blackUnbanAction;
 
     $titles_black[] = $black_list['title'][$i];


### PR DESCRIPTION
The params loop use the total of found items. But we need the count of elements in the array, which can be different from the total because of pagination.
The total can be 55, and the count from the array = 10 (because we display 10 elements per page).